### PR TITLE
Ensure Camunda transaction when updating user tasks

### DIFF
--- a/adapters/camunda7/src/main/java/io/vanillabp/cockpit/adapter/camunda7/service/Camunda7BusinessCockpitService.java
+++ b/adapters/camunda7/src/main/java/io/vanillabp/cockpit/adapter/camunda7/service/Camunda7BusinessCockpitService.java
@@ -130,15 +130,22 @@ public class Camunda7BusinessCockpitService<WA> implements BusinessCockpitServic
     public void aggregateChanged(
             final WA workflowAggregate,
             final String... userTaskIds) {
-        
-        taskService
-                .createTaskQuery()
-                .taskIdIn(userTaskIds)
-                .list()
-                .forEach(task -> userTaskEventHandler.notify(
-                        (TaskEntity) task,
-                        TaskListener.EVENTNAME_UPDATE));
-        
+
+        ((ProcessEngineConfigurationImpl) processEngine
+                .getProcessEngineConfiguration())
+                .getCommandExecutorTxRequired()
+                .<Void>execute(commandContext -> {
+                    taskService
+                            .createTaskQuery()
+                            .taskIdIn(userTaskIds)
+                            .list()
+                            .forEach(task -> userTaskEventHandler.notify(
+                                    (TaskEntity) task,
+                                    TaskListener.EVENTNAME_UPDATE)
+                            );
+                    return null;
+                });
+
     }
 
     @Override

--- a/adapters/camunda7/src/main/java/io/vanillabp/cockpit/adapter/camunda7/usertask/Camunda7UserTaskHandler.java
+++ b/adapters/camunda7/src/main/java/io/vanillabp/cockpit/adapter/camunda7/usertask/Camunda7UserTaskHandler.java
@@ -110,7 +110,7 @@ public class Camunda7UserTaskHandler extends UserTaskHandlerBase {
 
         final var i18nLanguages = properties.getI18nLanguages(processService.getWorkflowModuleId(), bpmnProcessId);
         final io.vanillabp.cockpit.adapter.common.usertask.events.UserTaskEvent userTaskEvent =
-                switch (task.getEventName()) {
+                switch (eventName) {
                     case TaskListener.EVENTNAME_CREATE:
                         UserTaskCreatedEvent userTaskCreatedEvent = new UserTaskCreatedEvent(task.getTenantId(), i18nLanguages);
                         fillUserTaskCreatedEvent(task, userTaskCreatedEvent);


### PR DESCRIPTION
When calling the business cockpit service from outside a Camunda transaction a NPE is thrown due to the missing Camunda command context. Futhermore, because the task event name is missing when getting triggered manually, another NPE is thrown while notifying.