### PR TITLE
Simplify local mongo db setup

### DIFF
--- a/container/src/main/resources/config/application-local.yaml
+++ b/container/src/main/resources/config/application-local.yaml
@@ -1,7 +1,7 @@
 spring:
   data:
     mongodb:
-      uri: mongodb://business-cockpit:business-cockpit@business-cockpit-mongo:27017/business-cockpit
+      uri: mongodb://business-cockpit:business-cockpit@127.0.0.1:27017/business-cockpit
 
 bpms-api:
   username: abc

--- a/development/docker-compose.yaml
+++ b/development/docker-compose.yaml
@@ -3,7 +3,6 @@ version: '3'
 services:
   business-cockpit-mongo:
     image: mongo:4.4
-    container_name: business-cockpit-mongo
     restart: "no"
     ports:
       - "27017:27017"
@@ -11,7 +10,6 @@ services:
   business-cockpit-mongo-setup:
     image: business-cockpit-mongo-setup
     build: ./mongo/
-    container_name: business-cockpit-mongo-setup
     restart: "no"
     depends_on:
       - business-cockpit-mongo

--- a/development/mongo/mongo-setup.js
+++ b/development/mongo/mongo-setup.js
@@ -3,7 +3,7 @@ rsconf = {
     members: [
         {
             "_id": 0,
-            "host": "business-cockpit-mongo:27017",
+            "host": "127.0.0.1:27017",
             "priority": 3
         }
     ]


### PR DESCRIPTION
A single-node-mongodb in cluster mode - which is sufficient for development - does not need custom hostnames to connect to docker server