### PR TITLE
Add workflow module ID for C8

### DIFF
--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/Camunda8AdapterConfiguration.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/Camunda8AdapterConfiguration.java
@@ -224,6 +224,7 @@ public class Camunda8AdapterConfiguration extends AdapterConfigurationBase<Camun
     public Camunda8DeploymentAdapter camunda8BusinessCockpitDeploymentAdapter(
             final VanillaBpProperties properties,
             final Camunda8VanillaBpProperties camunda8Properties,
+            final VanillaBpCockpitProperties cockpitProperties,
             final @Qualifier("camunda8BusinessCockpitDeploymentService") DeploymentService deploymentService,
             final Camunda8UserTaskWiring camunda8UserTaskWiring,
             final Camunda8WorkflowWiring camunda8WorkflowWiring){
@@ -232,6 +233,7 @@ public class Camunda8AdapterConfiguration extends AdapterConfigurationBase<Camun
                 applicationName,
                 properties,
                 camunda8Properties,
+                cockpitProperties,
                 deploymentService,
                 camunda8UserTaskWiring,
                 camunda8WorkflowWiring);

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/Camunda8AdapterConfiguration.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/Camunda8AdapterConfiguration.java
@@ -7,9 +7,11 @@ import io.vanillabp.cockpit.adapter.camunda8.deployments.DeploymentService;
 import io.vanillabp.cockpit.adapter.camunda8.deployments.ProcessInstancePersistence;
 import io.vanillabp.cockpit.adapter.camunda8.service.Camunda8BusinessCockpitService;
 import io.vanillabp.cockpit.adapter.camunda8.usertask.Camunda8UserTaskEventHandler;
+import io.vanillabp.cockpit.adapter.camunda8.usertask.Camunda8UserTaskHandler;
 import io.vanillabp.cockpit.adapter.camunda8.usertask.Camunda8UserTaskWiring;
 import io.vanillabp.cockpit.adapter.camunda8.usertask.publishing.Camunda8UserTaskEventPublisher;
 import io.vanillabp.cockpit.adapter.camunda8.workflow.Camunda8WorkflowEventHandler;
+import io.vanillabp.cockpit.adapter.camunda8.workflow.Camunda8WorkflowHandler;
 import io.vanillabp.cockpit.adapter.camunda8.workflow.Camunda8WorkflowWiring;
 import io.vanillabp.cockpit.adapter.common.CockpitCommonAdapterConfiguration;
 import io.vanillabp.cockpit.adapter.common.properties.VanillaBpCockpitProperties;
@@ -22,15 +24,20 @@ import io.vanillabp.springboot.adapter.AdapterAwareProcessService;
 import io.vanillabp.springboot.adapter.SpringBeanUtil;
 import io.vanillabp.springboot.adapter.SpringDataUtil;
 import io.vanillabp.springboot.adapter.VanillaBpProperties;
+import io.vanillabp.springboot.parameters.MethodParameter;
+import java.lang.reflect.Method;
 import java.math.BigInteger;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -39,7 +46,9 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Scope;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.retry.annotation.EnableRetry;
 
 @AutoConfigurationPackage(basePackageClasses = Camunda8AdapterConfiguration.class)
 @EnableConfigurationProperties(Camunda8VanillaBpProperties.class)
@@ -48,6 +57,7 @@ import org.springframework.data.repository.CrudRepository;
         "io.camunda.zeebe.spring.client.CamundaAutoConfiguration", // community-hub client
         "io.camunda.zeebe.spring.client.configuration.CamundaAutoConfiguration" // official client
 })
+@EnableRetry
 public class Camunda8AdapterConfiguration extends AdapterConfigurationBase<Camunda8BusinessCockpitService<?>> {
 
     public static final String ADAPTER_ID = "camunda8";
@@ -102,7 +112,8 @@ public class Camunda8AdapterConfiguration extends AdapterConfigurationBase<Camun
             @Qualifier(CockpitCommonAdapterConfiguration.TEMPLATING_QUALIFIER)
             final Optional<Configuration> templating,
             final Map<Class<?>, AdapterAwareProcessService<?>> connectableServices,
-            final Camunda8UserTaskEventHandler userTaskEventHandler
+            final Camunda8UserTaskEventHandler userTaskEventHandler,
+            final ObjectProvider<Camunda8UserTaskHandler> userTaskHandlers
     ) throws Exception {
         return new Camunda8UserTaskWiring(
                 applicationContext,
@@ -112,8 +123,67 @@ public class Camunda8AdapterConfiguration extends AdapterConfigurationBase<Camun
                 templating,
                 connectableServices,
                 userTaskEventHandler,
-                processInstancePersistence
+                processInstancePersistence,
+                userTaskHandlers
         );
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public Camunda8WorkflowHandler camunda8WorkflowHandler(
+            final VanillaBpCockpitProperties cockpitProperties,
+            final AdapterAwareProcessService<?> processService,
+            final String bpmnProcessId,
+            final String bpmnProcessName,
+            final Optional<Configuration> templating,
+            final CrudRepository<Object, Object> workflowAggregateRepository,
+            final Object bean,
+            final Method method,
+            final List<MethodParameter> parameters) {
+
+        return new Camunda8WorkflowHandler(
+                cockpitProperties,
+                processService,
+                bpmnProcessId,
+                bpmnProcessName,
+                templating,
+                workflowAggregateRepository,
+                bean,
+                method,
+                parameters);
+
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public Camunda8UserTaskHandler camunda8UserTaskHandler(
+            final String taskDefinition,
+            final VanillaBpCockpitProperties cockpitProperties,
+            final ApplicationEventPublisher applicationEventPublisher,
+            final Optional<Configuration> templating,
+            final String bpmnProcessId,
+            final String taskTitle,
+            final AdapterAwareProcessService<?> processService,
+            final ProcessInstancePersistence processInstancePersistence,
+            final CrudRepository<Object, Object> workflowAggregateRepository,
+            final Object bean,
+            final Method method,
+            final List<MethodParameter> parameters) {
+
+        return new Camunda8UserTaskHandler(
+                taskDefinition,
+                cockpitProperties,
+                applicationEventPublisher,
+                templating,
+                bpmnProcessId,
+                taskTitle,
+                processService,
+                processInstancePersistence,
+                workflowAggregateRepository,
+                bean,
+                method,
+                parameters);
+
     }
 
     @Bean
@@ -126,7 +196,8 @@ public class Camunda8AdapterConfiguration extends AdapterConfigurationBase<Camun
             @Qualifier(CockpitCommonAdapterConfiguration.TEMPLATING_QUALIFIER)
             final Optional<Configuration> templating,
             final Camunda8WorkflowEventHandler workflowEventListener,
-            final WorkflowModulePublishing workflowModulePublishing){
+            final WorkflowModulePublishing workflowModulePublishing,
+            final ObjectProvider<Camunda8WorkflowHandler> workflowHandlers) {
         return new Camunda8WorkflowWiring(
                 applicationContext,
                 cockpitProperties,
@@ -137,7 +208,8 @@ public class Camunda8AdapterConfiguration extends AdapterConfigurationBase<Camun
                 getConnectableServices(),
                 templating,
                 workflowEventListener,
-                workflowModulePublishing);
+                workflowModulePublishing,
+                workflowHandlers);
     }
 
     @Bean

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/Camunda8DeploymentAdapter.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/Camunda8DeploymentAdapter.java
@@ -16,6 +16,7 @@ import io.vanillabp.cockpit.adapter.camunda8.utils.HashCodeInputStream;
 import io.vanillabp.cockpit.adapter.camunda8.wiring.Camunda8UserTaskConnectable;
 import io.vanillabp.cockpit.adapter.camunda8.wiring.Camunda8WorkflowConnectable;
 import io.vanillabp.cockpit.adapter.camunda8.workflow.Camunda8WorkflowWiring;
+import io.vanillabp.cockpit.adapter.common.properties.VanillaBpCockpitProperties;
 import io.vanillabp.springboot.adapter.ModuleAwareBpmnDeployment;
 import io.vanillabp.springboot.adapter.VanillaBpProperties;
 import java.io.ByteArrayInputStream;
@@ -50,7 +51,7 @@ public class Camunda8DeploymentAdapter extends ModuleAwareBpmnDeployment {
 
     private final Camunda8VanillaBpProperties camunda8Properties;
 
-    private final VanillaBpProperties vanillaBpProperties;
+    private final VanillaBpCockpitProperties cockpitProperties;
 
     private ZeebeClient client;
 
@@ -58,14 +59,15 @@ public class Camunda8DeploymentAdapter extends ModuleAwareBpmnDeployment {
             final String applicationName,
             final VanillaBpProperties properties,
             final Camunda8VanillaBpProperties camunda8Properties,
+            final VanillaBpCockpitProperties cockpitProperties,
             final DeploymentService deploymentService,
             final Camunda8UserTaskWiring camunda8UserTaskWiring,
             final Camunda8WorkflowWiring camunda8WorkflowWiring) {
 
         super(properties, applicationName);
         this.camunda8Properties = camunda8Properties;
+        this.cockpitProperties = cockpitProperties;
         this.deploymentService = deploymentService;
-        this.vanillaBpProperties = properties;
         this.applicationName = applicationName;
         this.camunda8UserTaskWiring = camunda8UserTaskWiring;
         this.camunda8WorkflowWiring = camunda8WorkflowWiring;
@@ -92,7 +94,7 @@ public class Camunda8DeploymentAdapter extends ModuleAwareBpmnDeployment {
         this.client = event.getClient();
 
         // deploy only modules listed in configuration, if modules are in classpath not syncing to business cockpit
-        deploySelectedWorkflowModules(vanillaBpProperties.getWorkflowModules().keySet());
+        deploySelectedWorkflowModules(cockpitProperties.getWorkflowModules().keySet());
     }
 
     @Override

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/Camunda8DeploymentAdapter.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/Camunda8DeploymentAdapter.java
@@ -50,6 +50,8 @@ public class Camunda8DeploymentAdapter extends ModuleAwareBpmnDeployment {
 
     private final Camunda8VanillaBpProperties camunda8Properties;
 
+    private final VanillaBpProperties vanillaBpProperties;
+
     private ZeebeClient client;
 
     public Camunda8DeploymentAdapter(
@@ -63,6 +65,7 @@ public class Camunda8DeploymentAdapter extends ModuleAwareBpmnDeployment {
         super(properties, applicationName);
         this.camunda8Properties = camunda8Properties;
         this.deploymentService = deploymentService;
+        this.vanillaBpProperties = properties;
         this.applicationName = applicationName;
         this.camunda8UserTaskWiring = camunda8UserTaskWiring;
         this.camunda8WorkflowWiring = camunda8WorkflowWiring;
@@ -89,7 +92,7 @@ public class Camunda8DeploymentAdapter extends ModuleAwareBpmnDeployment {
         this.client = event.getClient();
 
         // deploy only modules listed in configuration, if modules are in classpath not syncing to business cockpit
-        deploySelectedWorkflowModules(camunda8Properties.getWorkflowModules().keySet());
+        deploySelectedWorkflowModules(vanillaBpProperties.getWorkflowModules().keySet());
     }
 
     @Override

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/Camunda8DeploymentAdapter.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/Camunda8DeploymentAdapter.java
@@ -88,7 +88,8 @@ public class Camunda8DeploymentAdapter extends ModuleAwareBpmnDeployment {
 
         this.client = event.getClient();
 
-        deployAllWorkflowModules();
+        // deploy only modules listed in configuration, if modules are in classpath not syncing to business cockpit
+        deploySelectedWorkflowModules(camunda8Properties.getWorkflowModules().keySet());
     }
 
     @Override
@@ -149,6 +150,7 @@ public class Camunda8DeploymentAdapter extends ModuleAwareBpmnDeployment {
                     .getProcesses()
                     .forEach(process ->  {
                         deploymentService.addProcess(
+                                workflowModuleId,
                                 deploymentHashCode[0],
                                 process,
                                 deployedProcesses.get(process.getBpmnProcessId()));
@@ -158,7 +160,7 @@ public class Camunda8DeploymentAdapter extends ModuleAwareBpmnDeployment {
 
         // BPMNs which were deployed in the past need to be forced to be parsed for wiring
         deploymentService
-                .getBpmnNotOfPackage(deploymentHashCode[0])
+                .getBpmnNotOfPackage(workflowModuleId, deploymentHashCode[0])
                 .forEach(bpmn -> {
                     try (var inputStream = new ByteArrayInputStream(
                             bpmn.getResource())) {

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/Deployment.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/Deployment.java
@@ -10,6 +10,8 @@ public interface Deployment {
 
     int getPackageId();
 
+    String getWorkflowModuleId();
+
     OffsetDateTime getPublishedAt();
 
     <R extends DeploymentResource> R getDeployedResource();

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/DeploymentPersistence.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/DeploymentPersistence.java
@@ -9,10 +9,15 @@ public interface DeploymentPersistence {
     Optional<? extends Deployment> findDeployedProcess(
             long definitionKey);
 
+    <R extends DeployedProcess> R updateMissingWorkflowModuleIdOfDeployedProcess(
+            R deployedProcess,
+            String workflowModuleId);
+
     <R extends DeployedProcess> R addDeployedProcess(
             long definitionKey,
             int version,
             int packageId,
+            String workflowModuleId,
             String bpmnProcessId,
             final DeployedBpmn bpmn,
             OffsetDateTime publishedAt);
@@ -26,6 +31,7 @@ public interface DeploymentPersistence {
             byte[] resource);
 
     List<? extends DeployedBpmn> getBpmnNotOfPackage(
-            final int packageId);
+            String workflowModuleId,
+            int packageId);
 
 }

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/jpa/DeployedBpmnRepository.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/jpa/DeployedBpmnRepository.java
@@ -9,6 +9,6 @@ public interface DeployedBpmnRepository extends JpaRepository<DeployedBpmn, Inte
 
     String BEAN_NAME = "Camunda8BusinessCockpitDeployedBpmnRepository";
 
-    List<DeployedBpmn> findByDeployments_packageIdNot(int packageId);
+    List<DeployedBpmn> findByDeployments_workflowModuleIdAndDeployments_PackageIdNot(String workflowModuleId, int packageId);
 
 }

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/jpa/Deployment.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/jpa/Deployment.java
@@ -38,6 +38,9 @@ public abstract class Deployment
     @Column(name = "C8D_PACKAGE_ID")
     private int packageId;
 
+    @Column(name = "C8D_WORKFLOWMODULE_ID")
+    private String workflowModuleId;
+
     @ManyToOne(optional = false)
     @JoinColumn(name = "C8D_RESOURCE", nullable = false, updatable = false)
     private DeploymentResource deployedResource;
@@ -91,6 +94,14 @@ public abstract class Deployment
     
     public void setRecordVersion(int recordVersion) {
         this.recordVersion = recordVersion;
+    }
+
+    public String getWorkflowModuleId() {
+        return workflowModuleId;
+    }
+
+    public void setWorkflowModuleId(String workflowModuleId) {
+        this.workflowModuleId = workflowModuleId;
     }
 
     @Override

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/jpa/JpaDeploymentPersistence.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/jpa/JpaDeploymentPersistence.java
@@ -38,10 +38,23 @@ public class JpaDeploymentPersistence implements DeploymentPersistence {
 
     @Override
     @SuppressWarnings("unchecked")
+    public <R extends DeployedProcess> R updateMissingWorkflowModuleIdOfDeployedProcess(
+            final R deployedProcess,
+            final String workflowModuleId) {
+
+        final var jpaDeployedProcess = (io.vanillabp.cockpit.adapter.camunda8.deployments.jpa.DeployedProcess) deployedProcess;
+        jpaDeployedProcess.setWorkflowModuleId(workflowModuleId);
+        return (R) deploymentRepository.save(jpaDeployedProcess);
+
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
     public <R extends DeployedProcess> R addDeployedProcess(
             final long definitionKey,
             final int version,
             final int packageId,
+            final String workflowModuleId,
             final String bpmnProcessId,
             final DeployedBpmn bpmn,
             final OffsetDateTime publishedAt) {
@@ -55,6 +68,7 @@ public class JpaDeploymentPersistence implements DeploymentPersistence {
         deployedProcess.setDefinitionKey(definitionKey);
         deployedProcess.setVersion(version);
         deployedProcess.setPackageId(packageId);
+        deployedProcess.setWorkflowModuleId(workflowModuleId);
         deployedProcess.setBpmnProcessId(bpmnProcessId);
         deployedProcess.setDeployedResource(bpmnEntity);
         deployedProcess.setPublishedAt(OffsetDateTime.now());
@@ -90,10 +104,11 @@ public class JpaDeploymentPersistence implements DeploymentPersistence {
 
     @Override
     public List<? extends DeployedBpmn> getBpmnNotOfPackage(
+            final String workflowModuleId,
             final int packageId) {
 
         return deployedBpmnRepository
-                .findByDeployments_packageIdNot(packageId)
+                .findByDeployments_workflowModuleIdAndDeployments_PackageIdNot(workflowModuleId, packageId)
                 .stream()
                 .distinct() // Oracle doesn't support distinct queries including blob columns, hence the job is done here
                 .toList();

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/mongodb/Deployment.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/mongodb/Deployment.java
@@ -29,6 +29,9 @@ public abstract class Deployment
     @Field(name = "C8D_PACKAGE_ID")
     private int packageId;
 
+    @Field(name = "C8D_WORKFLOWMODULE_ID")
+    private String workflowModuleId;
+
     @DocumentReference(
             collection = DeploymentResource.COLLECTION_NAME,
             lazy = true)
@@ -87,6 +90,15 @@ public abstract class Deployment
     
     public void setRecordVersion(int recordVersion) {
         this.recordVersion = recordVersion;
+    }
+
+    @Override
+    public String getWorkflowModuleId() {
+        return workflowModuleId;
+    }
+
+    public void setWorkflowModuleId(String workflowModuleId) {
+        this.workflowModuleId = workflowModuleId;
     }
 
     @Override

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/mongodb/MongoDbDeploymentPersistence.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/mongodb/MongoDbDeploymentPersistence.java
@@ -39,10 +39,23 @@ public class MongoDbDeploymentPersistence implements DeploymentPersistence {
 
     @Override
     @SuppressWarnings("unchecked")
+    public <R extends DeployedProcess> R updateMissingWorkflowModuleIdOfDeployedProcess(
+            final R deployedProcess,
+            final String workflowModuleId) {
+
+        final var mongoDeployedProcess = (io.vanillabp.cockpit.adapter.camunda8.deployments.mongodb.DeployedProcess) deployedProcess;
+        mongoDeployedProcess.setWorkflowModuleId(workflowModuleId);
+        return (R) deploymentRepository.save(mongoDeployedProcess);
+
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
     public <R extends DeployedProcess> R addDeployedProcess(
             final long definitionKey,
             final int version,
             final int packageId,
+            final String workflowModuleId,
             final String bpmnProcessId,
             final DeployedBpmn bpmn,
             final OffsetDateTime publishedAt) {
@@ -57,6 +70,7 @@ public class MongoDbDeploymentPersistence implements DeploymentPersistence {
         deployedProcess.setDefinitionKey(definitionKey);
         deployedProcess.setVersion(version);
         deployedProcess.setPackageId(packageId);
+        deployedProcess.setWorkflowModuleId(workflowModuleId);
         deployedProcess.setBpmnProcessId(bpmnProcessId);
         deployedProcess.setDeployedResource(bpmnEntity);
         deployedProcess.setPublishedAt(OffsetDateTime.now());
@@ -98,12 +112,16 @@ public class MongoDbDeploymentPersistence implements DeploymentPersistence {
 
     @Override
     public List<? extends DeployedBpmn> getBpmnNotOfPackage(
+            final String workflowModuleId,
             final int packageId) {
 
         return deployedBpmnRepository
                 .findAll()
                 .stream()
-                .filter(deployedBpmn -> deployedBpmn.getDeployments().stream().anyMatch(deployment -> deployment.getPackageId() != packageId))
+                .filter(deployedBpmn -> deployedBpmn.getDeployments().stream().anyMatch(deployment ->
+                        deployment.getWorkflowModuleId() != null
+                        && workflowModuleId.equals(deployment.getWorkflowModuleId())
+                        && deployment.getPackageId() != packageId))
                 .distinct()
                 .toList();
 

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/workflow/Camunda8WorkflowWiring.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/workflow/Camunda8WorkflowWiring.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.repository.CrudRepository;
 
@@ -42,6 +43,8 @@ public class Camunda8WorkflowWiring extends AbstractWorkflowWiring<Camunda8UserT
 
     private final Camunda8VanillaBpProperties camunda8Properties;
 
+    private final ObjectProvider<Camunda8WorkflowHandler> workflowHandlers;
+
     public Camunda8WorkflowWiring(
             final ApplicationContext applicationContext,
             final VanillaBpCockpitProperties properties,
@@ -52,7 +55,8 @@ public class Camunda8WorkflowWiring extends AbstractWorkflowWiring<Camunda8UserT
             final Collection<Camunda8BusinessCockpitService<?>> connectableCockpitServices,
             final Optional<Configuration> templating,
             final Camunda8WorkflowEventHandler workflowEventListener,
-            final WorkflowModulePublishing workflowModulePublishing) {
+            final WorkflowModulePublishing workflowModulePublishing,
+            final ObjectProvider<Camunda8WorkflowHandler> workflowHandlers) {
         super(applicationContext, springBeanUtil, methodParameterFactory, workflowModulePublishing);
         this.properties = properties;
         this.connectableServices = connectableServices;
@@ -60,6 +64,7 @@ public class Camunda8WorkflowWiring extends AbstractWorkflowWiring<Camunda8UserT
         this.workflowEventListener = workflowEventListener;
         this.templating = templating;
         this.camunda8Properties = camunda8Properties;
+        this.workflowHandlers = workflowHandlers;
     }
 
     public Camunda8BusinessCockpitService<?> wireService(
@@ -220,7 +225,7 @@ public class Camunda8WorkflowWiring extends AbstractWorkflowWiring<Camunda8UserT
         String bpmnProcessId = connectable.bpmnProcessId();
 
         @SuppressWarnings("unchecked")
-        final var workflowHandler = new Camunda8WorkflowHandler(
+        final var workflowHandler = workflowHandlers.getObject(
                 properties,
                 processService,
                 bpmnProcessId,

--- a/adapters/camunda8/src/main/resources/io/vanillabp/cockpit/adapter/camunda8/liquibase/add_wfm_id.yaml
+++ b/adapters/camunda8/src/main/resources/io/vanillabp/cockpit/adapter/camunda8/liquibase/add_wfm_id.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-workflow-module-id
+      author: stephanpelikan
+      changes:
+        - addColumn:
+            tableName: CAMUNDA8_BC_DEPLOYMENTS
+            columns:
+              - column:
+                  name: C8D_WORKFLOWMODULE_ID
+                  type: varchar(255)

--- a/adapters/camunda8/src/main/resources/io/vanillabp/cockpit/adapter/camunda8/liquibase/main.yaml
+++ b/adapters/camunda8/src/main/resources/io/vanillabp/cockpit/adapter/camunda8/liquibase/main.yaml
@@ -2,3 +2,6 @@ databaseChangeLog:
   - include:
       relativeToChangelogFile: true
       file: initial_setup.yaml
+  - include:
+      relativeToChangelogFile: true
+      file: add_wfm_id.yaml

--- a/adapters/commons/src/main/java/io/vanillabp/cockpit/adapter/common/properties/VanillaBpCockpitProperties.java
+++ b/adapters/commons/src/main/java/io/vanillabp/cockpit/adapter/common/properties/VanillaBpCockpitProperties.java
@@ -1,13 +1,12 @@
 package io.vanillabp.cockpit.adapter.common.properties;
 
 import io.vanillabp.springboot.adapter.VanillaBpProperties;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.util.StringUtils;
-
 import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
 
 @ConfigurationProperties(prefix = VanillaBpProperties.PREFIX, ignoreUnknownFields = true)
 public class VanillaBpCockpitProperties {
@@ -38,27 +37,11 @@ public class VanillaBpCockpitProperties {
 
     }
 
-    private WorkflowModuleAdapterProperties getWorkflowModule(
-            final String workflowModuleId) {
-
-        final var workflowModule = getWorkflowModules().get(workflowModuleId);
-        if (workflowModule == null) {
-            throw new RuntimeException(
-                    "No property '"
-                            + VanillaBpProperties.PREFIX
-                            + ".workflow-modules."
-                            + workflowModuleId
-                            + "' found!");
-        }
-        return workflowModule;
-
-    }
-
     public String getUiUriType(
             final String workflowModuleId) {
 
-        final var workflowModule = getWorkflowModule(workflowModuleId);
-        final var uiUriType = workflowModule.getCockpit().getUiUriType();
+        final var workflowModule = getWorkflowModules().get(workflowModuleId);
+        final var uiUriType = workflowModule == null ? null : workflowModule.getCockpit().getUiUriType();
         if (!StringUtils.hasText(uiUriType)) {
             throw new RuntimeException(
                     "Property for UI-URI-type not found:\n  "
@@ -74,8 +57,8 @@ public class VanillaBpCockpitProperties {
     public String getWorkflowModuleUri(
             final String workflowModuleId) {
 
-        final var workflowModule = getWorkflowModule(workflowModuleId);
-        final var workflowModuleUri = workflowModule.getCockpit().getWorkflowModuleUri();
+        final var workflowModule = getWorkflowModules().get(workflowModuleId);
+        final var workflowModuleUri = workflowModule == null ? null : workflowModule.getCockpit().getWorkflowModuleUri();
         if (!StringUtils.hasText(workflowModuleUri)) {
             throw new RuntimeException(
                     "Property for workflow-module-uri not found:\n  "
@@ -92,8 +75,8 @@ public class VanillaBpCockpitProperties {
     public String getUiUriPath(
             final String workflowModuleId) {
 
-        final var workflowModule = getWorkflowModule(workflowModuleId);
-        final var uiUriPath = workflowModule.getCockpit().getUiUriPath();
+        final var workflowModule = getWorkflowModules().get(workflowModuleId);
+        final var uiUriPath = workflowModule == null ? null : workflowModule.getCockpit().getUiUriPath();
         if (!StringUtils.hasText(uiUriPath)) {
             throw new RuntimeException(
                     "Property for UI-URI-path not found:\n  "
@@ -110,9 +93,9 @@ public class VanillaBpCockpitProperties {
             final String workflowModuleId,
             final String bpmnProcessId) {
 
-        final var workflowModule = getWorkflowModule(workflowModuleId);
-        var i18nLanguages = workflowModule.getCockpit().getI18nLanguages();
-        final var workflow = workflowModule.getWorkflows().get(bpmnProcessId);
+        final var workflowModule = getWorkflowModules().get(workflowModuleId);
+        var i18nLanguages = workflowModule == null ? null : workflowModule.getCockpit().getI18nLanguages();
+        final var workflow = workflowModule == null ? null : workflowModule.getWorkflows().get(bpmnProcessId);
         if ((workflow != null)
                 && (workflow.getCockpit().getI18nLanguages() != null)) {
             i18nLanguages = workflow.getCockpit().getI18nLanguages();
@@ -139,9 +122,9 @@ public class VanillaBpCockpitProperties {
             final String workflowModuleId,
             final String bpmnProcessId) {
 
-        final var workflowModule = getWorkflowModule(workflowModuleId);
-        var language = workflowModule.getCockpit().getBpmnDescriptionLanguage();
-        final var workflow = workflowModule.getWorkflows().get(bpmnProcessId);
+        final var workflowModule = getWorkflowModules().get(workflowModuleId);
+        var language = workflowModule == null ? null : workflowModule.getCockpit().getBpmnDescriptionLanguage();
+        final var workflow = workflowModule == null ? null : workflowModule.getWorkflows().get(bpmnProcessId);
         if ((workflow != null)
                 && StringUtils.hasText(workflow.getCockpit().getBpmnDescriptionLanguage())) {
             language = workflow.getCockpit().getBpmnDescriptionLanguage();

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
       <dependency>
         <groupId>io.vanillabp</groupId>
         <artifactId>spring-boot-support</artifactId>
-        <version>1.2.1</version>
+        <version>1.2.2-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Old BPMNs were deploy-t also for non-matching workflow module because it was not stored to which they belong to.

Depends on:
https://github.com/camunda-community-hub/vanillabp-camunda8-adapter/pull/79
