### PR TITLE
Add missing uriType to completed and canceled events of user-task

### DIFF
--- a/adapters/commons/src/main/java/io/vanillabp/cockpit/adapter/common/usertask/rest/UserTaskRestPublishing.java
+++ b/adapters/commons/src/main/java/io/vanillabp/cockpit/adapter/common/usertask/rest/UserTaskRestPublishing.java
@@ -64,11 +64,13 @@ public class UserTaskRestPublishing extends UserTaskPublishingBase implements Us
 
         } else if (eventObject instanceof UserTaskCompletedEvent userTaskCompletedEvent) {
 
+            editUserTaskCreatedOrUpdatedEvent(userTaskCompletedEvent);
             final var event = userTaskMapper.map(userTaskCompletedEvent);
             bpmsApi.get().userTaskCompletedEvent(eventObject.getUserTaskId(), event);
 
         } else if (eventObject instanceof UserTaskCancelledEvent userTaskCancelledEvent) {
 
+            editUserTaskCreatedOrUpdatedEvent(userTaskCancelledEvent);
             final var event = userTaskMapper.map(userTaskCancelledEvent);
             bpmsApi.get().userTaskCancelledEvent(eventObject.getUserTaskId(), event);
 


### PR DESCRIPTION
This is about the BPMS REST API - no effects to BPMS Kafka API.