### PR TITLE
Use Camunda Client 8.9.x

### DIFF
--- a/adapters/camunda7/pom.xml
+++ b/adapters/camunda7/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>adapters</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/adapters/camunda8/pom.xml
+++ b/adapters/camunda8/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.vanillabp.businesscockpit</groupId>
         <artifactId>adapters</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camunda8-spring-boot-adapter</artifactId>

--- a/adapters/camunda8/pom.xml
+++ b/adapters/camunda8/pom.xml
@@ -37,8 +37,8 @@
 
         <dependency>
             <groupId>io.camunda</groupId>
-            <artifactId>camunda-spring-boot-starter</artifactId>
-            <version>8.8.8</version>
+            <artifactId>camunda-spring-boot-3-starter</artifactId>
+            <version>8.9.11</version>
         </dependency>
 
         <dependency>

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/Camunda8AdapterConfiguration.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/Camunda8AdapterConfiguration.java
@@ -6,6 +6,7 @@ import io.camunda.client.api.JsonMapper;
 import io.vanillabp.cockpit.adapter.camunda8.deployments.Camunda8DeploymentAdapter;
 import io.vanillabp.cockpit.adapter.camunda8.service.Camunda8BusinessCockpitService;
 import io.vanillabp.cockpit.adapter.camunda8.service.Camunda8BusinessCockpitSupportService;
+import io.vanillabp.cockpit.adapter.camunda8.service.CockpitClientCleanupService;
 import io.vanillabp.cockpit.adapter.camunda8.usertask.Camunda8UserTaskEventHandler;
 import io.vanillabp.cockpit.adapter.camunda8.usertask.Camunda8UserTaskHandler;
 import io.vanillabp.cockpit.adapter.camunda8.usertask.Camunda8UserTaskWiring;
@@ -356,4 +357,10 @@ public class Camunda8AdapterConfiguration extends AdapterConfigurationBase<Camun
 
     }
 
+    @Bean
+    public CockpitClientCleanupService cockpitClientCleanupService(Camunda8DeploymentAdapter deploymentAdapter,
+                                                                   Camunda8UserTaskWiring userTaskWiring,
+                                                                   Camunda8WorkflowWiring workflowWiring) {
+        return new CockpitClientCleanupService(deploymentAdapter, userTaskWiring, workflowWiring);
+    }
 }

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/Camunda8DeploymentAdapter.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/deployments/Camunda8DeploymentAdapter.java
@@ -703,4 +703,12 @@ public class Camunda8DeploymentAdapter extends ModuleAwareBpmnDeployment {
     ){
         return element.getAttributeValue("name");
     }
+
+    /**
+     * Only necessary for Spring Boot tests / @CamundaSpringProcessTest.
+     * After one test has completed, we need to reinitialize the deployment priority list.
+     */
+    public void doCleanup() {
+        initializeCrossCuttingProperties();
+    }
 }

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/service/CockpitClientCleanupService.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/service/CockpitClientCleanupService.java
@@ -1,0 +1,37 @@
+package io.vanillabp.cockpit.adapter.camunda8.service;
+
+import io.camunda.client.event.CamundaClientClosingEvent;
+import io.vanillabp.cockpit.adapter.camunda8.deployments.Camunda8DeploymentAdapter;
+import io.vanillabp.cockpit.adapter.camunda8.usertask.Camunda8UserTaskWiring;
+import io.vanillabp.cockpit.adapter.camunda8.workflow.Camunda8WorkflowWiring;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+
+/**
+ * In Spring Boot tests, where application contexts are reused, we do not want to keep references to old
+ * Repositories / CamundaClients. These should be recreated when required.
+ */
+public class CockpitClientCleanupService {
+    private static final Logger logger = LoggerFactory.getLogger(CockpitClientCleanupService.class);
+
+    private final Camunda8DeploymentAdapter deploymentAdapter;
+    private final Camunda8UserTaskWiring userTaskWiring;
+    private final Camunda8WorkflowWiring workflowWiring;
+
+    public CockpitClientCleanupService(Camunda8DeploymentAdapter deploymentAdapter,
+                                       Camunda8UserTaskWiring userTaskWiring,
+                                       Camunda8WorkflowWiring workflowWiring) {
+        this.deploymentAdapter = deploymentAdapter;
+        this.userTaskWiring = userTaskWiring;
+        this.workflowWiring = workflowWiring;
+    }
+
+    @EventListener
+    public void onContextClosed(CamundaClientClosingEvent event) {
+        logger.debug("Camunda client closed, cleaning up: {}", event);
+        deploymentAdapter.doCleanup();
+        userTaskWiring.doCleanup();
+        workflowWiring.doCleanup();
+    }
+}

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/usertask/Camunda8UserTaskEventHandler.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/usertask/Camunda8UserTaskEventHandler.java
@@ -42,6 +42,10 @@ public class Camunda8UserTaskEventHandler implements JobHandler {
         
     }
 
+    public void doCleanup() {
+        this.taskHandlers.clear();
+    }
+
     public void processCreatedEvent(
             final Camunda8UserTaskCreatedEvent userTaskCreatedEvent) {
         processEvent(

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/usertask/Camunda8UserTaskWiring.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/usertask/Camunda8UserTaskWiring.java
@@ -114,6 +114,11 @@ public class Camunda8UserTaskWiring extends AbstractUserTaskWiring<Camunda8UserT
 
     }
 
+    public void doCleanup() {
+        userTaskEventHandler.doCleanup();
+        workers.clear();
+    }
+
     public void wireTask(
             final String workflowModuleId,
             final Camunda8UserTaskConnectable connectable) {

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/workflow/Camunda8WorkflowEventHandler.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/workflow/Camunda8WorkflowEventHandler.java
@@ -41,6 +41,10 @@ public class Camunda8WorkflowEventHandler implements JobHandler {
         this.workflowHandlers.put(connectable, workflowHandler);
     }
 
+    public void doCleanup() {
+        this.workflowHandlers.clear();
+    }
+
     public void processCreatedEvent(Camunda8WorkflowCreatedEvent workflowCreatedEvent) {
         processEvent(
                 workflowCreatedEvent.getTenantId(),

--- a/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/workflow/Camunda8WorkflowWiring.java
+++ b/adapters/camunda8/src/main/java/io/vanillabp/cockpit/adapter/camunda8/workflow/Camunda8WorkflowWiring.java
@@ -123,6 +123,11 @@ public class Camunda8WorkflowWiring extends AbstractWorkflowWiring<Camunda8UserT
 
     }
 
+    public void doCleanup() {
+        workflowEventHandler.doCleanup();
+        workers.clear();
+    }
+
     public Camunda8BusinessCockpitService<?> wireService(
             final String workflowModuleId,
             final Camunda8WorkflowConnectable camunda8WorkflowConnectable) {

--- a/adapters/commons/pom.xml
+++ b/adapters/commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>adapters</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>adapters-commons</artifactId>

--- a/adapters/commons/src/main/java/io/vanillabp/cockpit/adapter/common/properties/VanillaBpCockpitProperties.java
+++ b/adapters/commons/src/main/java/io/vanillabp/cockpit/adapter/common/properties/VanillaBpCockpitProperties.java
@@ -49,7 +49,7 @@ public class VanillaBpCockpitProperties {
                             + VanillaBpProperties.PREFIX
                             + ".workflow-modules."
                             + workflowModuleId
-                            + ".ui-uri-type");
+                            + ".cockpit.ui-uri-type");
         }
         return uiUriType;
 
@@ -66,7 +66,7 @@ public class VanillaBpCockpitProperties {
                             + VanillaBpProperties.PREFIX
                             + ".workflow-modules."
                             + workflowModuleId
-                            + ".workflow-module-uri\n"
+                            + ".cockpit.workflow-module-uri\n"
                             + "You may wish to use a property since the endpoint might defined later: ${containerUri}/my-workflow-module");
         }
         return workflowModuleUri;
@@ -84,7 +84,7 @@ public class VanillaBpCockpitProperties {
                             + VanillaBpProperties.PREFIX
                             + ".workflow-modules."
                             + workflowModuleId
-                            + ".ui-uri-path");
+                            + ".cockpit.ui-uri-path");
         }
         return uiUriPath;
 

--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>business-cockpit-parent</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>adapters</artifactId>

--- a/apis/bpms-api/client/pom.xml
+++ b/apis/bpms-api/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>bpms-api</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>bpms-api-client</artifactId>

--- a/apis/bpms-api/pom.xml
+++ b/apis/bpms-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>apis</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>bpms-api</artifactId>

--- a/apis/bpms-api/protobuf/pom.xml
+++ b/apis/bpms-api/protobuf/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.vanillabp.businesscockpit</groupId>
         <artifactId>bpms-api</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>bpms-protobuf-api</artifactId>

--- a/apis/bpms-api/server-reactive/pom.xml
+++ b/apis/bpms-api/server-reactive/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>bpms-api</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>bpms-api-server-reactive</artifactId>

--- a/apis/bpms-api/server/pom.xml
+++ b/apis/bpms-api/server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>bpms-api</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>bpms-api-server</artifactId>

--- a/apis/official-gui-api/client/package-lock.json
+++ b/apis/official-gui-api/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vanillabp/bc-official-gui-client",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanillabp/bc-official-gui-client",
-      "version": "0.2.1-SNAPSHOT.0",
+      "version": "0.3.0-SNAPSHOT.0",
       "devDependencies": {
         "@types/node": "25.0.9",
         "@types/web": "0.0.319",
@@ -1229,9 +1229,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/apis/official-gui-api/client/package.json
+++ b/apis/official-gui-api/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillabp/bc-official-gui-client",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/vanillabp/business-cockpit.git"

--- a/apis/official-gui-api/client/pom.xml
+++ b/apis/official-gui-api/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>official-gui-api</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/apis/official-gui-api/pom.xml
+++ b/apis/official-gui-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.vanillabp.businesscockpit</groupId>
         <artifactId>apis</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>official-gui-api</artifactId>

--- a/apis/official-gui-api/server-reactive/pom.xml
+++ b/apis/official-gui-api/server-reactive/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>official-gui-api</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>official-gui-api-server-reactive</artifactId>

--- a/apis/official-gui-api/server/pom.xml
+++ b/apis/official-gui-api/server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>official-gui-api</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>official-gui-api-server</artifactId>

--- a/apis/pom.xml
+++ b/apis/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>business-cockpit-parent</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apis</artifactId>

--- a/apis/workflow-provider-api/client/pom.xml
+++ b/apis/workflow-provider-api/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>workflow-provider-api</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>workflow-provider-api-client</artifactId>

--- a/apis/workflow-provider-api/pom.xml
+++ b/apis/workflow-provider-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>apis</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>workflow-provider-api</artifactId>

--- a/apis/workflow-provider-api/server/pom.xml
+++ b/apis/workflow-provider-api/server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>workflow-provider-api</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>workflow-provider-api-server</artifactId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>business-cockpit-parent</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>commons</artifactId>

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>business-cockpit-parent</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>container</artifactId>

--- a/container/src/main/webapp/package-lock.json
+++ b/container/src/main/webapp/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "vanillabp-business-cockpit",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vanillabp-business-cockpit",
-      "version": "0.2.1-SNAPSHOT.0",
+      "version": "0.3.0-SNAPSHOT.0",
       "dependencies": {
         "@fontsource/roboto": "4.5.8",
         "@microsoft/fetch-event-source": "2.0.1",
-        "@vanillabp/bc-shared": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-ui": ">=0.2.1-SNAPSHOT <0.2.2",
+        "@vanillabp/bc-shared": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-ui": ">=0.3.0-SNAPSHOT <0.3.1",
         "grommet": "2.33.2",
         "grommet-icons": "4.12.1",
         "i18next": "22.0.3",
@@ -4745,18 +4745,18 @@
       "license": "ISC"
     },
     "node_modules/@vanillabp/bc-official-gui-client": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/0.2.1-SNAPSHOT.0/4fd7f574631d1b39cf05e1c34b992efb2a30437f",
-      "integrity": "sha512-r9WiIiheB0AA8U5aisoQcMzGj3F0LwpiCVphK/r8r9NbQ2FQZqYusVkSqbA4D6eqNMMjS7qyJmsm7EClmzxP0g=="
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/-/bc-official-gui-client-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-l+Jk4tvjGdufCtzQY8qzdVeih6RmLIAO/seCToc89BMADaZ+mNlNKfHssaGhXVHetGPb+Z5crJYuZLrpf1OwdA=="
     },
     "node_modules/@vanillabp/bc-shared": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-shared/0.2.1-SNAPSHOT.0/5639c457db86742111c91eeb3d2e823687f62373",
-      "integrity": "sha512-IgyYvpCOQd2s0oyI06cs2bIkrTeAVmu5flnbUYulq25lgiEi2pz4ESxSf0CEe/RiR0Fl5Jf+FEzUGSubN1VguA==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-shared/-/bc-shared-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-it93KKdwcJCw7nABG+WhZFeR7RmSh+TnkGp48etvryIdICnG1VlgTLiy1V/V2kqYnbQlj4jT6ThlitVcdBk5Nw==",
       "dependencies": {
         "@microsoft/fetch-event-source": "2.0.1",
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2",
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1",
         "react-cookie": "4.1.1",
         "usehooks-ts": "2.7.1"
       },
@@ -4775,21 +4775,21 @@
       }
     },
     "node_modules/@vanillabp/bc-types": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-types/0.2.1-SNAPSHOT.0/317eda2d401f1af6908c08cc2139d181c19567c5",
-      "integrity": "sha512-kmTkrYT7S1u6VDdaQgeS/7NiGt3GkfGf6WzW7DGYuMVUsYiJPaEYeBZ3gxzHmFxr0KyUZkgxuUtXQkGxWjz2Ng==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-types/-/bc-types-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-yC50ohRM0WElQZ65acYa7bbOmDTjfexCgtP54wATIq7heUk1YHCuW5kzZ+TbQkGMTJYDR8hOC1N87cYyq0zI0g==",
       "peerDependencies": {
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2"
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1"
       }
     },
     "node_modules/@vanillabp/bc-ui": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-ui/0.2.1-SNAPSHOT.0/d516b3cf2dc76e6b75eb5c5aca1699a6093bb27e",
-      "integrity": "sha512-V3mXnZGbaX0p9Izhz76Atk1aINZwvC2xdt3Lf9PZHFr97y3I0VNvDHW0MYHUl+B+QaenoSzbZNwZ3YuNLmzjjQ==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-ui/-/bc-ui-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-9w4QYWau9PQmSwH/Zi+y7tmF2WImr2BrOo6dNEUHIO24YHC3evzYabUrqtwVhlhZIBspwZA4OyaWY98+1ByoLQ==",
       "dependencies": {
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-shared": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2"
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-shared": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1"
       },
       "peerDependencies": {
         "@fontsource/roboto": "4.5.8",
@@ -6100,9 +6100,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.10.41",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
+      "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -6471,9 +6471,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "funding": [
         {
           "type": "opencollective",
@@ -8122,9 +8122,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.381",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz",
-      "integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
+      "version": "1.5.385",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
+      "integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -8621,9 +8621,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
-      "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18242,9 +18242,9 @@
       }
     },
     "node_modules/styled-components/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -18942,9 +18942,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/container/src/main/webapp/package.json
+++ b/container/src/main/webapp/package.json
@@ -1,10 +1,10 @@
 {
   "name": "vanillabp-business-cockpit",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "private": true,
   "dependencies": {
-    "@vanillabp/bc-shared": ">=0.2.1-SNAPSHOT <0.2.2",
-    "@vanillabp/bc-ui": ">=0.2.1-SNAPSHOT <0.2.2",
+    "@vanillabp/bc-shared": ">=0.3.0-SNAPSHOT <0.3.1",
+    "@vanillabp/bc-ui": ">=0.3.0-SNAPSHOT <0.3.1",
     "@fontsource/roboto": "4.5.8",
     "grommet": "2.33.2",
     "grommet-icons": "4.12.1",

--- a/development/dev-shell-angular/package-lock.json
+++ b/development/dev-shell-angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vanillabp/bc-dev-shell-angular-module",
-  "version": "0.2.1-SNAPSHOT",
+  "version": "0.3.0-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanillabp/bc-dev-shell-angular-module",
-      "version": "0.2.1-SNAPSHOT",
+      "version": "0.3.0-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^17.2.0",
         "@angular/common": "^17.2.0",
@@ -3374,9 +3374,9 @@
       }
     },
     "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4057,9 +4057,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
-      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4793,9 +4793,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.10.41",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
+      "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5157,9 +5157,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "dev": true,
       "funding": [
         {
@@ -6092,9 +6092,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.381",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz",
-      "integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
+      "version": "1.5.385",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
+      "integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
       "dev": true,
       "license": "ISC"
     },

--- a/development/dev-shell-angular/package.json
+++ b/development/dev-shell-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillabp/bc-dev-shell-angular-module",
-  "version": "0.2.1-SNAPSHOT",
+  "version": "0.3.0-SNAPSHOT",
   "private": true,
   "repository": {
     "type": "git",

--- a/development/dev-shell-angular/pom.xml
+++ b/development/dev-shell-angular/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>development</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/development/dev-shell-angular/projects/dev-shell/package.json
+++ b/development/dev-shell-angular/projects/dev-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillabp/bc-dev-shell-angular",
-  "version": "0.2.1-SNAPSHOT",
+  "version": "0.3.0-SNAPSHOT",
   "repository": {
     "type": "git",
     "url": "https://github.com/vanillabp/business-cockpit.git"
@@ -10,8 +10,8 @@
     "@angular/common": "^17.2.0",
     "@angular/core": "^17.2.0",
     "@angular/router": "^17.2.0",
-    "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-    "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2"
+    "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+    "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/development/dev-shell-react/package-lock.json
+++ b/development/dev-shell-react/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@vanillabp/bc-dev-shell-react",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanillabp/bc-dev-shell-react",
-      "version": "0.2.1-SNAPSHOT.0",
+      "version": "0.3.0-SNAPSHOT.0",
       "dependencies": {
         "@microsoft/fetch-event-source": "2.0.1",
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-shared": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2",
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-shared": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1",
         "react-cookie": "4.1.1",
         "usehooks-ts": "2.7.1"
       },
@@ -4970,18 +4970,18 @@
       "license": "MIT"
     },
     "node_modules/@vanillabp/bc-official-gui-client": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/0.2.1-SNAPSHOT.0/4fd7f574631d1b39cf05e1c34b992efb2a30437f",
-      "integrity": "sha512-r9WiIiheB0AA8U5aisoQcMzGj3F0LwpiCVphK/r8r9NbQ2FQZqYusVkSqbA4D6eqNMMjS7qyJmsm7EClmzxP0g=="
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/-/bc-official-gui-client-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-l+Jk4tvjGdufCtzQY8qzdVeih6RmLIAO/seCToc89BMADaZ+mNlNKfHssaGhXVHetGPb+Z5crJYuZLrpf1OwdA=="
     },
     "node_modules/@vanillabp/bc-shared": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-shared/0.2.1-SNAPSHOT.0/5639c457db86742111c91eeb3d2e823687f62373",
-      "integrity": "sha512-IgyYvpCOQd2s0oyI06cs2bIkrTeAVmu5flnbUYulq25lgiEi2pz4ESxSf0CEe/RiR0Fl5Jf+FEzUGSubN1VguA==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-shared/-/bc-shared-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-it93KKdwcJCw7nABG+WhZFeR7RmSh+TnkGp48etvryIdICnG1VlgTLiy1V/V2kqYnbQlj4jT6ThlitVcdBk5Nw==",
       "dependencies": {
         "@microsoft/fetch-event-source": "2.0.1",
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2",
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1",
         "react-cookie": "4.1.1",
         "usehooks-ts": "2.7.1"
       },
@@ -5000,11 +5000,11 @@
       }
     },
     "node_modules/@vanillabp/bc-types": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-types/0.2.1-SNAPSHOT.0/317eda2d401f1af6908c08cc2139d181c19567c5",
-      "integrity": "sha512-kmTkrYT7S1u6VDdaQgeS/7NiGt3GkfGf6WzW7DGYuMVUsYiJPaEYeBZ3gxzHmFxr0KyUZkgxuUtXQkGxWjz2Ng==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-types/-/bc-types-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-yC50ohRM0WElQZ65acYa7bbOmDTjfexCgtP54wATIq7heUk1YHCuW5kzZ+TbQkGMTJYDR8hOC1N87cYyq0zI0g==",
       "peerDependencies": {
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2"
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -5969,9 +5969,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.10.41",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
+      "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -6445,9 +6445,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "funding": [
         {
           "type": "opencollective",
@@ -7762,9 +7762,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.381",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz",
-      "integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
+      "version": "1.5.385",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
+      "integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -7929,9 +7929,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -14082,9 +14082,9 @@
       }
     },
     "node_modules/styled-components/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -14664,9 +14664,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/development/dev-shell-react/package.json
+++ b/development/dev-shell-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillabp/bc-dev-shell-react",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/vanillabp/business-cockpit.git"
@@ -17,9 +17,9 @@
   ],
   "dependencies": {
     "@microsoft/fetch-event-source": "2.0.1",
-    "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-    "@vanillabp/bc-shared": ">=0.2.1-SNAPSHOT <0.2.2",
-    "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2",
+    "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+    "@vanillabp/bc-shared": ">=0.3.0-SNAPSHOT <0.3.1",
+    "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1",
     "react-cookie": "4.1.1",
     "usehooks-ts": "2.7.1"
   },

--- a/development/dev-shell-react/pom.xml
+++ b/development/dev-shell-react/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>development</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/development/dev-shell-simulator/pom.xml
+++ b/development/dev-shell-simulator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>development</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dev-shell-simulator</artifactId>

--- a/development/dev-shell-vue/package-lock.json
+++ b/development/dev-shell-vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vanillabp/bc-dev-shell-vue",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanillabp/bc-dev-shell-vue",
-      "version": "0.2.1-SNAPSHOT.0",
+      "version": "0.3.0-SNAPSHOT.0",
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.0.0",
         "primevue": "^4.3.0",
@@ -20,8 +20,8 @@
       },
       "peerDependencies": {
         "@primevue/themes": "^4.3.0",
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2",
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1",
         "primevue": "^4.3.0",
         "vue": "^3.5.0",
         "vue-router": "^4.0.0"
@@ -1156,18 +1156,18 @@
       "license": "MIT"
     },
     "node_modules/@vanillabp/bc-official-gui-client": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/0.2.1-SNAPSHOT.0/4fd7f574631d1b39cf05e1c34b992efb2a30437f",
-      "integrity": "sha512-r9WiIiheB0AA8U5aisoQcMzGj3F0LwpiCVphK/r8r9NbQ2FQZqYusVkSqbA4D6eqNMMjS7qyJmsm7EClmzxP0g==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/-/bc-official-gui-client-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-l+Jk4tvjGdufCtzQY8qzdVeih6RmLIAO/seCToc89BMADaZ+mNlNKfHssaGhXVHetGPb+Z5crJYuZLrpf1OwdA==",
       "peer": true
     },
     "node_modules/@vanillabp/bc-types": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-types/0.2.1-SNAPSHOT.0/317eda2d401f1af6908c08cc2139d181c19567c5",
-      "integrity": "sha512-kmTkrYT7S1u6VDdaQgeS/7NiGt3GkfGf6WzW7DGYuMVUsYiJPaEYeBZ3gxzHmFxr0KyUZkgxuUtXQkGxWjz2Ng==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-types/-/bc-types-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-yC50ohRM0WElQZ65acYa7bbOmDTjfexCgtP54wATIq7heUk1YHCuW5kzZ+TbQkGMTJYDR8hOC1N87cYyq0zI0g==",
       "peer": true,
       "peerDependencies": {
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2"
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1"
       }
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -1956,9 +1956,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/development/dev-shell-vue/package.json
+++ b/development/dev-shell-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillabp/bc-dev-shell-vue",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -17,8 +17,8 @@
     "postpublish": "node -e \"if(process.env.WAIT_FOR_NPM_PUBLISH==='1'){const cp=require('child_process');const root=process.env.GITHUB_WORKSPACE||cp.execSync('git rev-parse --show-toplevel').toString().trim();cp.execSync('bash \\\"'+root+'/.github/scripts/wait-for-npm-publish.sh\\\"',{stdio:'inherit'})}\""
   },
   "peerDependencies": {
-    "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-    "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2",
+    "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+    "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1",
     "primevue": "^4.3.0",
     "@primevue/themes": "^4.3.0",
     "vue": "^3.5.0",

--- a/development/dev-shell-vue/pom.xml
+++ b/development/dev-shell-vue/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>development</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/development/pom.xml
+++ b/development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>business-cockpit-parent</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>development</artifactId>

--- a/development/simulator/pom.xml
+++ b/development/simulator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>development</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>simulator</artifactId>

--- a/development/simulator/src/main/webapp-angular/package-lock.json
+++ b/development/simulator/src/main/webapp-angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webapp-angular",
-  "version": "0.2.1-SNAPSHOT",
+  "version": "0.3.0-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webapp-angular",
-      "version": "0.2.1-SNAPSHOT",
+      "version": "0.3.0-SNAPSHOT",
       "dependencies": {
         "@angular/animations": "^17.2.0",
         "@angular/common": "^17.2.0",
@@ -17,8 +17,8 @@
         "@angular/platform-browser": "^17.2.0",
         "@angular/platform-browser-dynamic": "^17.2.0",
         "@angular/router": "^17.2.0",
-        "@vanillabp/bc-dev-shell-angular": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-shared": ">=0.2.1-SNAPSHOT <0.2.2",
+        "@vanillabp/bc-dev-shell-angular": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-shared": ">=0.3.0-SNAPSHOT <0.3.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.3"
@@ -3564,9 +3564,9 @@
       }
     },
     "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4866,9 +4866,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
-      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4994,9 +4994,9 @@
       }
     },
     "node_modules/@vanillabp/bc-dev-shell-angular": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-dev-shell-angular/0.2.1-SNAPSHOT.0/5709fe6843c7211118bf24da6ccd478c0e303dd6",
-      "integrity": "sha512-+UXVBli3t8RzrKVTpjXkzOWBmtmLduDT2dl6aYN2B7JVHpAVUPeGy4h1y5Z7oar/uHoXcUVhZLE0qvgVu+xB9Q==",
+      "version": "0.3.0-SNAPSHOT",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-dev-shell-angular/-/bc-dev-shell-angular-0.3.0-SNAPSHOT.tgz",
+      "integrity": "sha512-J5G6jE+siyo5+RTYtb5Fh4yjBKAhlE/JpUGHOHduQvbAijfst60/2yvWvtFsTmSYlkPi2nn7DfxHhDsJdy9JSQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -5004,23 +5004,23 @@
         "@angular/common": "^17.2.0",
         "@angular/core": "^17.2.0",
         "@angular/router": "^17.2.0",
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2"
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1"
       }
     },
     "node_modules/@vanillabp/bc-official-gui-client": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/0.2.1-SNAPSHOT.0/4fd7f574631d1b39cf05e1c34b992efb2a30437f",
-      "integrity": "sha512-r9WiIiheB0AA8U5aisoQcMzGj3F0LwpiCVphK/r8r9NbQ2FQZqYusVkSqbA4D6eqNMMjS7qyJmsm7EClmzxP0g=="
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/-/bc-official-gui-client-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-l+Jk4tvjGdufCtzQY8qzdVeih6RmLIAO/seCToc89BMADaZ+mNlNKfHssaGhXVHetGPb+Z5crJYuZLrpf1OwdA=="
     },
     "node_modules/@vanillabp/bc-shared": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-shared/0.2.1-SNAPSHOT.0/5639c457db86742111c91eeb3d2e823687f62373",
-      "integrity": "sha512-IgyYvpCOQd2s0oyI06cs2bIkrTeAVmu5flnbUYulq25lgiEi2pz4ESxSf0CEe/RiR0Fl5Jf+FEzUGSubN1VguA==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-shared/-/bc-shared-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-it93KKdwcJCw7nABG+WhZFeR7RmSh+TnkGp48etvryIdICnG1VlgTLiy1V/V2kqYnbQlj4jT6ThlitVcdBk5Nw==",
       "dependencies": {
         "@microsoft/fetch-event-source": "2.0.1",
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2",
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1",
         "react-cookie": "4.1.1",
         "usehooks-ts": "2.7.1"
       },
@@ -5039,11 +5039,11 @@
       }
     },
     "node_modules/@vanillabp/bc-types": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-types/0.2.1-SNAPSHOT.0/317eda2d401f1af6908c08cc2139d181c19567c5",
-      "integrity": "sha512-kmTkrYT7S1u6VDdaQgeS/7NiGt3GkfGf6WzW7DGYuMVUsYiJPaEYeBZ3gxzHmFxr0KyUZkgxuUtXQkGxWjz2Ng==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-types/-/bc-types-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-yC50ohRM0WElQZ65acYa7bbOmDTjfexCgtP54wATIq7heUk1YHCuW5kzZ+TbQkGMTJYDR8hOC1N87cYyq0zI0g==",
       "peerDependencies": {
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2"
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1"
       }
     },
     "node_modules/@vitejs/plugin-basic-ssl": {
@@ -5923,9 +5923,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.10.41",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
+      "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -6294,9 +6294,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "funding": [
         {
           "type": "opencollective",
@@ -7431,9 +7431,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.381",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz",
-      "integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
+      "version": "1.5.385",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
+      "integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -7689,9 +7689,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -10287,9 +10287,9 @@
       }
     },
     "node_modules/lint-staged/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14616,9 +14616,9 @@
       }
     },
     "node_modules/styled-components/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/development/simulator/src/main/webapp-angular/package.json
+++ b/development/simulator/src/main/webapp-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp-angular",
-  "version": "0.2.1-SNAPSHOT",
+  "version": "0.3.0-SNAPSHOT",
   "scripts": {
     "ng": "ng",
     "prettier": "prettier --write \"**/*.{js,json,css,scss,less,md,ts,html,component.html}\"",
@@ -15,8 +15,8 @@
   },
   "private": true,
   "dependencies": {
-    "@vanillabp/bc-shared": ">=0.2.1-SNAPSHOT <0.2.2",
-    "@vanillabp/bc-dev-shell-angular": ">=0.2.1-SNAPSHOT <0.2.2",
+    "@vanillabp/bc-shared": ">=0.3.0-SNAPSHOT <0.3.1",
+    "@vanillabp/bc-dev-shell-angular": ">=0.3.0-SNAPSHOT <0.3.1",
     "@angular/animations": "^17.2.0",
     "@angular/common": "^17.2.0",
     "@angular/compiler": "^17.2.0",

--- a/development/simulator/src/main/webapp-angular/projects/library/package.json
+++ b/development/simulator/src/main/webapp-angular/projects/library/package.json
@@ -1,11 +1,11 @@
 {
   "name": "library",
-  "version": "0.2.1-SNAPSHOT",
+  "version": "0.3.0-SNAPSHOT",
   "peerDependencies": {
     "@angular/common": "^17.2.0",
     "@angular/core": "^17.2.0",
-    "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-    "@vanillabp/bc-shared": ">=0.2.1-SNAPSHOT <0.2.2"
+    "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+    "@vanillabp/bc-shared": ">=0.3.0-SNAPSHOT <0.3.1"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/development/simulator/src/main/webapp-react/package-lock.json
+++ b/development/simulator/src/main/webapp-react/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "test-module",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "test-module",
-      "version": "0.2.1-SNAPSHOT.0",
+      "version": "0.3.0-SNAPSHOT.0",
       "dependencies": {
         "@fontsource/roboto": "4.5.8",
         "@microsoft/fetch-event-source": "2.0.1",
-        "@vanillabp/bc-dev-shell-react": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-shared": ">=0.2.1-SNAPSHOT <0.2.2",
+        "@vanillabp/bc-dev-shell-react": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-shared": ">=0.3.0-SNAPSHOT <0.3.1",
         "grommet": "2.33.2",
         "grommet-icons": "4.12.1",
         "i18next": "22.0.3",
@@ -4048,9 +4048,9 @@
       }
     },
     "node_modules/@parcel/watcher/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -5482,14 +5482,14 @@
       "license": "ISC"
     },
     "node_modules/@vanillabp/bc-dev-shell-react": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-dev-shell-react/0.2.1-SNAPSHOT.0/e04277c9a8fe3446816c461391f546dee9e62141",
-      "integrity": "sha512-QsALygUN3SGvjCV3a7rxfdqnuUBtxC1gqScqfazxk36FARUj1GylvgkPaJhvU5zsKX+qwfhrpaLbkanFb5rPIQ==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-dev-shell-react/-/bc-dev-shell-react-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-HWmXFjSZGUY+Uh67SFz0nKon+QFjtTE5MvyrP9rqiVNVSxMzlnxI3I9myfsp0elAx/vA5fZTvaHJsgZmX9zkDg==",
       "dependencies": {
         "@microsoft/fetch-event-source": "2.0.1",
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-shared": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2",
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-shared": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1",
         "react-cookie": "4.1.1",
         "usehooks-ts": "2.7.1"
       },
@@ -5507,18 +5507,18 @@
       }
     },
     "node_modules/@vanillabp/bc-official-gui-client": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/0.2.1-SNAPSHOT.0/4fd7f574631d1b39cf05e1c34b992efb2a30437f",
-      "integrity": "sha512-r9WiIiheB0AA8U5aisoQcMzGj3F0LwpiCVphK/r8r9NbQ2FQZqYusVkSqbA4D6eqNMMjS7qyJmsm7EClmzxP0g=="
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/-/bc-official-gui-client-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-l+Jk4tvjGdufCtzQY8qzdVeih6RmLIAO/seCToc89BMADaZ+mNlNKfHssaGhXVHetGPb+Z5crJYuZLrpf1OwdA=="
     },
     "node_modules/@vanillabp/bc-shared": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-shared/0.2.1-SNAPSHOT.0/5639c457db86742111c91eeb3d2e823687f62373",
-      "integrity": "sha512-IgyYvpCOQd2s0oyI06cs2bIkrTeAVmu5flnbUYulq25lgiEi2pz4ESxSf0CEe/RiR0Fl5Jf+FEzUGSubN1VguA==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-shared/-/bc-shared-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-it93KKdwcJCw7nABG+WhZFeR7RmSh+TnkGp48etvryIdICnG1VlgTLiy1V/V2kqYnbQlj4jT6ThlitVcdBk5Nw==",
       "dependencies": {
         "@microsoft/fetch-event-source": "2.0.1",
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2",
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1",
         "react-cookie": "4.1.1",
         "usehooks-ts": "2.7.1"
       },
@@ -5537,11 +5537,11 @@
       }
     },
     "node_modules/@vanillabp/bc-types": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-types/0.2.1-SNAPSHOT.0/317eda2d401f1af6908c08cc2139d181c19567c5",
-      "integrity": "sha512-kmTkrYT7S1u6VDdaQgeS/7NiGt3GkfGf6WzW7DGYuMVUsYiJPaEYeBZ3gxzHmFxr0KyUZkgxuUtXQkGxWjz2Ng==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-types/-/bc-types-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-yC50ohRM0WElQZ65acYa7bbOmDTjfexCgtP54wATIq7heUk1YHCuW5kzZ+TbQkGMTJYDR8hOC1N87cYyq0zI0g==",
       "peerDependencies": {
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2"
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -6872,9 +6872,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.10.41",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
+      "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -7243,9 +7243,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "funding": [
         {
           "type": "opencollective",
@@ -8977,9 +8977,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.381",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz",
-      "integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
+      "version": "1.5.385",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
+      "integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -9226,9 +9226,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -9479,9 +9479,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
-      "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20320,9 +20320,9 @@
       }
     },
     "node_modules/styled-components/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -21061,9 +21061,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/development/simulator/src/main/webapp-react/package.json
+++ b/development/simulator/src/main/webapp-react/package.json
@@ -1,11 +1,11 @@
 {
   "name": "test-module",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "private": true,
   "dependencies": {
-    "@vanillabp/bc-shared": ">=0.2.1-SNAPSHOT <0.2.2",
-    "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-    "@vanillabp/bc-dev-shell-react": ">=0.2.1-SNAPSHOT <0.2.2",
+    "@vanillabp/bc-shared": ">=0.3.0-SNAPSHOT <0.3.1",
+    "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+    "@vanillabp/bc-dev-shell-react": ">=0.3.0-SNAPSHOT <0.3.1",
     "@fontsource/roboto": "4.5.8",
     "@microsoft/fetch-event-source": "2.0.1",
     "grommet": "2.33.2",

--- a/openapi-generator-fixes/pom.xml
+++ b/openapi-generator-fixes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>business-cockpit-parent</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>openapi-generator-fixes</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
       <dependency>
         <groupId>io.vanillabp</groupId>
         <artifactId>spring-boot-support</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>io.vanillabp.businesscockpit</groupId>
   <artifactId>business-cockpit-parent</artifactId>
-  <version>0.2.1-SNAPSHOT</version>
+  <version>0.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>VanillaBP business cockpit</name>
 

--- a/spi-for-java/pom.xml
+++ b/spi-for-java/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>business-cockpit-parent</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>spi-for-java</artifactId>

--- a/ui/bc-shared/package-lock.json
+++ b/ui/bc-shared/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@vanillabp/bc-shared",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanillabp/bc-shared",
-      "version": "0.2.1-SNAPSHOT.0",
+      "version": "0.3.0-SNAPSHOT.0",
       "dependencies": {
         "@microsoft/fetch-event-source": "2.0.1",
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2",
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1",
         "react-cookie": "4.1.1",
         "usehooks-ts": "2.7.1"
       },
@@ -5476,16 +5476,16 @@
       "license": "MIT"
     },
     "node_modules/@vanillabp/bc-official-gui-client": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/0.2.1-SNAPSHOT.0/4fd7f574631d1b39cf05e1c34b992efb2a30437f",
-      "integrity": "sha512-r9WiIiheB0AA8U5aisoQcMzGj3F0LwpiCVphK/r8r9NbQ2FQZqYusVkSqbA4D6eqNMMjS7qyJmsm7EClmzxP0g=="
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/-/bc-official-gui-client-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-l+Jk4tvjGdufCtzQY8qzdVeih6RmLIAO/seCToc89BMADaZ+mNlNKfHssaGhXVHetGPb+Z5crJYuZLrpf1OwdA=="
     },
     "node_modules/@vanillabp/bc-types": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-types/0.2.1-SNAPSHOT.0/317eda2d401f1af6908c08cc2139d181c19567c5",
-      "integrity": "sha512-kmTkrYT7S1u6VDdaQgeS/7NiGt3GkfGf6WzW7DGYuMVUsYiJPaEYeBZ3gxzHmFxr0KyUZkgxuUtXQkGxWjz2Ng==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-types/-/bc-types-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-yC50ohRM0WElQZ65acYa7bbOmDTjfexCgtP54wATIq7heUk1YHCuW5kzZ+TbQkGMTJYDR8hOC1N87cYyq0zI0g==",
       "peerDependencies": {
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2"
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -6561,9 +6561,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.10.41",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
+      "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -7081,9 +7081,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "funding": [
         {
           "type": "opencollective",
@@ -8478,9 +8478,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.381",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz",
-      "integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
+      "version": "1.5.385",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
+      "integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -8658,9 +8658,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -15933,9 +15933,9 @@
       }
     },
     "node_modules/styled-components/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -16536,9 +16536,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ui/bc-shared/package.json
+++ b/ui/bc-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillabp/bc-shared",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/vanillabp/business-cockpit.git"
@@ -17,8 +17,8 @@
   ],
   "dependencies": {
     "@microsoft/fetch-event-source": "2.0.1",
-    "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-    "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2",
+    "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+    "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1",
     "react-cookie": "4.1.1",
     "usehooks-ts": "2.7.1"
   },

--- a/ui/bc-shared/pom.xml
+++ b/ui/bc-shared/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>ui</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/ui/bc-types/package-lock.json
+++ b/ui/bc-types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vanillabp/bc-types",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanillabp/bc-types",
-      "version": "0.2.1-SNAPSHOT.0",
+      "version": "0.3.0-SNAPSHOT.0",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "8.53.1",
         "@typescript-eslint/parser": "8.53.1",
@@ -17,7 +17,7 @@
         "typescript": "5.9.3"
       },
       "peerDependencies": {
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2"
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1354,9 +1354,9 @@
       }
     },
     "node_modules/@vanillabp/bc-official-gui-client": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/0.2.1-SNAPSHOT.0/4fd7f574631d1b39cf05e1c34b992efb2a30437f",
-      "integrity": "sha512-r9WiIiheB0AA8U5aisoQcMzGj3F0LwpiCVphK/r8r9NbQ2FQZqYusVkSqbA4D6eqNMMjS7qyJmsm7EClmzxP0g==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/-/bc-official-gui-client-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-l+Jk4tvjGdufCtzQY8qzdVeih6RmLIAO/seCToc89BMADaZ+mNlNKfHssaGhXVHetGPb+Z5crJYuZLrpf1OwdA==",
       "peer": true
     },
     "node_modules/acorn": {
@@ -2418,9 +2418,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ui/bc-types/package.json
+++ b/ui/bc-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillabp/bc-types",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "description": "Library providing shared types for VanillaBP UI development",
   "author": "Phactum Softwareentwicklung GmbH",
   "repository": {
@@ -43,6 +43,6 @@
     "typescript": "5.9.3"
   },
   "peerDependencies": {
-    "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2"
+    "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1"
   }
 }

--- a/ui/bc-types/pom.xml
+++ b/ui/bc-types/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.vanillabp.businesscockpit</groupId>
         <artifactId>ui</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>bc-types</artifactId>

--- a/ui/bc-ui/package-lock.json
+++ b/ui/bc-ui/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@vanillabp/bc-ui",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanillabp/bc-ui",
-      "version": "0.2.1-SNAPSHOT.0",
+      "version": "0.3.0-SNAPSHOT.0",
       "dependencies": {
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-shared": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2"
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-shared": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1"
       },
       "devDependencies": {
         "@babel/preset-env": "7.21.4",
@@ -4965,18 +4965,18 @@
       "license": "MIT"
     },
     "node_modules/@vanillabp/bc-official-gui-client": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/0.2.1-SNAPSHOT.0/4fd7f574631d1b39cf05e1c34b992efb2a30437f",
-      "integrity": "sha512-r9WiIiheB0AA8U5aisoQcMzGj3F0LwpiCVphK/r8r9NbQ2FQZqYusVkSqbA4D6eqNMMjS7qyJmsm7EClmzxP0g=="
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-official-gui-client/-/bc-official-gui-client-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-l+Jk4tvjGdufCtzQY8qzdVeih6RmLIAO/seCToc89BMADaZ+mNlNKfHssaGhXVHetGPb+Z5crJYuZLrpf1OwdA=="
     },
     "node_modules/@vanillabp/bc-shared": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-shared/0.2.1-SNAPSHOT.0/5639c457db86742111c91eeb3d2e823687f62373",
-      "integrity": "sha512-IgyYvpCOQd2s0oyI06cs2bIkrTeAVmu5flnbUYulq25lgiEi2pz4ESxSf0CEe/RiR0Fl5Jf+FEzUGSubN1VguA==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-shared/-/bc-shared-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-it93KKdwcJCw7nABG+WhZFeR7RmSh+TnkGp48etvryIdICnG1VlgTLiy1V/V2kqYnbQlj4jT6ThlitVcdBk5Nw==",
       "dependencies": {
         "@microsoft/fetch-event-source": "2.0.1",
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-        "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2",
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+        "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1",
         "react-cookie": "4.1.1",
         "usehooks-ts": "2.7.1"
       },
@@ -4995,11 +4995,11 @@
       }
     },
     "node_modules/@vanillabp/bc-types": {
-      "version": "0.2.1-SNAPSHOT.0",
-      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-types/0.2.1-SNAPSHOT.0/317eda2d401f1af6908c08cc2139d181c19567c5",
-      "integrity": "sha512-kmTkrYT7S1u6VDdaQgeS/7NiGt3GkfGf6WzW7DGYuMVUsYiJPaEYeBZ3gxzHmFxr0KyUZkgxuUtXQkGxWjz2Ng==",
+      "version": "0.3.0-SNAPSHOT.0",
+      "resolved": "https://npm.pkg.github.com/download/@vanillabp/bc-types/-/bc-types-0.3.0-SNAPSHOT.0.tgz",
+      "integrity": "sha512-yC50ohRM0WElQZ65acYa7bbOmDTjfexCgtP54wATIq7heUk1YHCuW5kzZ+TbQkGMTJYDR8hOC1N87cYyq0zI0g==",
       "peerDependencies": {
-        "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2"
+        "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -5964,9 +5964,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.10.41",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
+      "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -6440,9 +6440,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
       "funding": [
         {
           "type": "opencollective",
@@ -7757,9 +7757,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.381",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz",
-      "integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
+      "version": "1.5.385",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
+      "integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -7924,9 +7924,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -14042,9 +14042,9 @@
       }
     },
     "node_modules/styled-components/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -14624,9 +14624,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ui/bc-ui/package.json
+++ b/ui/bc-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vanillabp/bc-ui",
-  "version": "0.2.1-SNAPSHOT.0",
+  "version": "0.3.0-SNAPSHOT.0",
   "sideEffects": false,
   "repository": {
     "type": "git",
@@ -16,9 +16,9 @@
     "package.json"
   ],
   "dependencies": {
-    "@vanillabp/bc-official-gui-client": ">=0.2.1-SNAPSHOT <0.2.2",
-    "@vanillabp/bc-shared": ">=0.2.1-SNAPSHOT <0.2.2",
-    "@vanillabp/bc-types": ">=0.2.1-SNAPSHOT <0.2.2"
+    "@vanillabp/bc-official-gui-client": ">=0.3.0-SNAPSHOT <0.3.1",
+    "@vanillabp/bc-shared": ">=0.3.0-SNAPSHOT <0.3.1",
+    "@vanillabp/bc-types": ">=0.3.0-SNAPSHOT <0.3.1"
   },
   "peerDependencies": {
     "@fontsource/roboto": "4.5.8",

--- a/ui/bc-ui/pom.xml
+++ b/ui/bc-ui/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.vanillabp.businesscockpit</groupId>
     <artifactId>ui</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>bc-ui</artifactId>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.vanillabp.businesscockpit</groupId>
         <artifactId>business-cockpit-parent</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ui</artifactId>


### PR DESCRIPTION
This MR primarily updates the Camunda Client to 8.9.

It also introduces a cleanup mechanism when the Camunda Client is closed, useful for tests with `@CamundaSpringProcessTest`. Lastly, it fixes some error messages regarding cockpit config properties.

Every change has a separate commit, so reviewing separately is possible.